### PR TITLE
Relax gemspec for Rails 6

### DIFF
--- a/parliament.gemspec
+++ b/parliament.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 5.0"
+  s.add_dependency "rails", ">= 5.0"
 
   s.add_development_dependency "pry"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
We needed to relax the gemspec to support Rails 6.0.0.beta1 and higher :) 